### PR TITLE
Implement / refactor notifications in the settings page

### DIFF
--- a/chrome/settings/settings.html
+++ b/chrome/settings/settings.html
@@ -25,8 +25,11 @@
         <!-- Quill.js Editor -->
         <div id="editor"></div>
 
-        <div class="notification is-warning is-hidden">
-          <button class="delete"></button>
+        <div class="notification is-link is-hidden success">
+          Signature successfully saved!
+        </div>
+
+        <div class="notification is-warning is-hidden warning">
           Oops! Looks like you forgot to add a signature. Go ahead and do that now
           before continuing.
         </div>

--- a/chrome/settings/settings.js
+++ b/chrome/settings/settings.js
@@ -29,16 +29,14 @@ clearBtn.addEventListener('click', () => {
   editor.deleteText(0, editorLength, 'api');
 });
 
-const hideNotificationBtn = document.querySelector('button.delete');
-const notification = hideNotificationBtn.parentElement;
-hideNotificationBtn.addEventListener('click', () => {
-  notification.classList.add('is-hidden');
-});
+// Notifications used for displaying info to the user to provide better UX
+const warningNotification = document.querySelector('div.notification.warning');
+const successNotification = document.querySelector('div.notification.success');
 
 chrome.runtime.onMessage.addListener(eventData => {
   switch (eventData.action) {
     case 'enable_warning':
-      notification.classList.remove('is-hidden');
+      showNotification(warningNotification);
       break;
     default:
       break;
@@ -55,11 +53,20 @@ function loadSignatureFromStorage () {
 
 function saveSignatureToStorage (contents) {
   const signature = contents;
-  chrome.storage.local.set(signature, function () {});
+  chrome.storage.local.set(signature, () => {
+    showNotification(successNotification);
+  });
 }
 
 function setSavedSignature (signature) {
   editor.setContents(signature);
+}
+
+function showNotification (notification) {
+  notification.classList.remove('is-hidden');
+  setTimeout(() => {
+    notification.classList.add('is-hidden');
+  }, 3000);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/firefox/settings/settings.html
+++ b/firefox/settings/settings.html
@@ -24,8 +24,11 @@
         <!-- Quill.js Editor -->
         <div id="editor"></div>
 
-        <div class="notification is-warning is-hidden">
-          <button class="delete"></button>
+        <div class="notification is-link is-hidden success">
+          Signature successfully saved!
+        </div>
+
+        <div class="notification is-warning is-hidden warning">
           Oops! Looks like you forgot to add a signature. Go ahead and do that now
           before continuing.
         </div>

--- a/firefox/settings/settings.js
+++ b/firefox/settings/settings.js
@@ -22,16 +22,14 @@ clearBtn.addEventListener('click', () => {
   editor.deleteText(0, editorLength, 'api');
 });
 
-const hideNotificationBtn = document.querySelector('button.delete');
-const notification = hideNotificationBtn.parentElement;
-hideNotificationBtn.addEventListener('click', () => {
-  notification.classList.add('is-hidden');
-});
+// Notifications used for displaying info to the user to provide better UX
+const warningNotification = document.querySelector('div.notification.warning');
+const successNotification = document.querySelector('div.notification.success');
 
 browser.runtime.onMessage.addListener(eventData => {
   switch (eventData.action) {
     case 'enable_warning':
-      notification.classList.remove('is-hidden');
+      showNotification(warningNotification);
       break;
     default:
       break;
@@ -49,11 +47,21 @@ function loadSignatureFromStorage () {
 
 function saveSignatureToStorage (contents) {
   const signature = contents;
-  browser.storage.local.set(signature);
+  browser.storage.local.set(signature)
+    .then(() => {
+      showNotification(successNotification);
+    });
 }
 
 function setSavedSignature (signature) {
   editor.setContents(signature);
+}
+
+function showNotification (notification) {
+  notification.classList.remove('is-hidden');
+  setTimeout(() => {
+    notification.classList.add('is-hidden');
+  }, 3000);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
Fixes #6. Previously, there was a single notification that would warn the user to add a signature before trying to use the signature button in Medium.

This adds a new notification (`successNotification`) that appears whenever the user saves their signature, adding to the overall UX. With the addition of this new notification, some minor refactoring was done.